### PR TITLE
Fixed compilation warnings

### DIFF
--- a/src/control/XournalMain.cpp
+++ b/src/control/XournalMain.cpp
@@ -213,10 +213,6 @@ int XournalMain::run(int argc, char* argv[])
 	}
 	g_option_context_free(context);
 
-#ifdef DEV_MEMORY_LEAK_CHECKING
-	xoj_type_initMutex();
-#endif
-
 	if (optNoPdfCompress)
 	{
 		PdfWriter::setCompressPdfOutput(false);

--- a/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
+++ b/src/gui/dialog/toolbarCustomize/ToolbarDragDropHelper.cpp
@@ -5,7 +5,7 @@
 #include <Util.h>
 
 GdkAtom ToolbarDragDropHelper::atomToolItem = gdk_atom_intern_static_string("application/xournal-ToolbarItem");
-GtkTargetEntry ToolbarDragDropHelper::dropTargetEntry = { "move-buffer", GTK_TARGET_SAME_APP, 1 };
+GtkTargetEntry ToolbarDragDropHelper::dropTargetEntry = { (gchar *)"move-buffer", GTK_TARGET_SAME_APP, 1 };
 
 ToolbarDragDropHelper::ToolbarDragDropHelper() { }
 
@@ -58,7 +58,7 @@ void ToolbarDragDropHelper::dragDestAddToolbar(GtkWidget* target)
 	// If not exist add, else do nothing
 	if (!gtk_target_list_find(targetList, atomToolItem, NULL))
 	{
-		gtk_target_list_add(targetList, atomToolItem, 0, NULL);
+		gtk_target_list_add(targetList, atomToolItem, 0, 0);
 	}
 
 	gtk_drag_dest_set_target_list(target, targetList);
@@ -82,7 +82,7 @@ void ToolbarDragDropHelper::dragSourceAddToolbar(GtkWidget* widget)
 	{
 		targetList = gtk_target_list_new(NULL, 0);
 	}
-	gtk_target_list_add(targetList, atomToolItem, 0, NULL);
+	gtk_target_list_add(targetList, atomToolItem, 0, 0);
 	gtk_drag_source_set_target_list(widget, targetList);
 	gtk_target_list_unref(targetList);
 }

--- a/src/gui/widgets/ZoomCallib.cpp
+++ b/src/gui/widgets/ZoomCallib.cpp
@@ -16,7 +16,7 @@ GtkType zoomcallib_get_type(void)
 	if (!zoomcallib_type)
 	{
 		static const GtkTypeInfo zoomcallib_info = {
-			"ZoomCallib",
+			(gchar *)"ZoomCallib",
 			sizeof(ZoomCallib),
 			sizeof(ZoomCallibClass),
 			(GtkClassInitFunc) zoomcallib_class_init,

--- a/src/util/XournalType.cpp
+++ b/src/util/XournalType.cpp
@@ -24,8 +24,7 @@ using std::endl;
 
 static bool listInited = false;
 static const char* xojTypeList[XOURNAL_TYPE_LIST_LENGTH] = { 0 };
-
-GMutex* mutex = NULL;
+static GMutex mutex = { 0 };
 
 static void initXournalClassList()
 {
@@ -36,27 +35,16 @@ static void initXournalClassList()
 	#include "XournalTypeList.h"
 }
 
-void xoj_type_initMutex()
-{
-	mutex = g_mutex_new();
-}
-
 const char* xoj_type_getName(int id)
 {
-	if (mutex)
-	{
-		g_mutex_lock(mutex);
-	}
+	g_mutex_lock(&mutex);
 	
 	if (!listInited)
 	{
 		initXournalClassList();
 	}
 
-	if (mutex)
-	{
-		g_mutex_unlock(mutex);
-	}
+	g_mutex_unlock(&mutex);
 
 	if (id < 0)
 	{
@@ -80,28 +68,16 @@ static int xojInstanceList[XOURNAL_TYPE_LIST_LENGTH] = { 0 };
 
 void xoj_memoryleak_initType(int id)
 {
-	if (mutex)
-	{
-		g_mutex_lock(mutex);
-	}
+	g_mutex_lock(&mutex);
 	xojInstanceList[id]++;
-	if (mutex)
-	{
-		g_mutex_unlock(mutex);
-	}
+	g_mutex_unlock(&mutex);
 }
 
 void xoj_memoryleak_releaseType(int id)
 {
-	if (mutex)
-	{
-		g_mutex_lock(mutex);
-	}
+	g_mutex_lock(&mutex);
 	xojInstanceList[id]--;
-	if (mutex)
-	{
-		g_mutex_unlock(mutex);
-	}
+	g_mutex_unlock(&mutex);
 }
 
 void xoj_momoryleak_printRemainingObjects()

--- a/src/util/XournalType.h
+++ b/src/util/XournalType.h
@@ -37,8 +37,6 @@ void xoj_momoryleak_printRemainingObjects();
 #define CALL_LOG(type, clazz, obj)
 #endif
 
-void xoj_type_initMutex();
-
 #define XOJ_DECLARE_TYPE(type, id) \
 	const int __XOJ_TYPE_ ## type = id
 


### PR DESCRIPTION
This commit fixes the following warnings during the compilation:
- ‘GMutex\* g_mutex_new()’ is deprecated
- ISO C++ forbids converting a string constant to ‘gchar\* {aka char*}’
- passing NULL to non-pointer argument [...]

The GMutex can be statically allocated since GLib 2.32, so no stricter dependencies are required.
